### PR TITLE
Include *.lck Core Lock file-type

### DIFF
--- a/pkg/msvc-uwp/RetroArch-msvcUWP/RetroArch-msvcUWP.vcxproj
+++ b/pkg/msvc-uwp/RetroArch-msvcUWP/RetroArch-msvcUWP.vcxproj
@@ -274,6 +274,10 @@
       <DeploymentContent>true</DeploymentContent>
       <Link>cores\%(Filename)%(Extension)</Link>
     </None>
+    <None Include="cores\$(Platform)\cores\*.lck">
+      <DeploymentContent>true</DeploymentContent>
+      <Link>cores\%(Filename)%(Extension)</Link>
+    </None>
     <None Include="cores\$(Platform)\*.dll">
       <DeploymentContent>true</DeploymentContent>
       <Link>%(Filename)%(Extension)</Link>

--- a/pkg/msvc-uwp/RetroArch-msvcUWP/RetroArch-msvcUWP.vcxproj.filters
+++ b/pkg/msvc-uwp/RetroArch-msvcUWP/RetroArch-msvcUWP.vcxproj.filters
@@ -19,10 +19,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="cores\$(Platform)\cores\*.dll" />
-    <None Include="cores\$(Platform)\*.dll" />
-    <None Include="RetroArch-msvcUWP_TemporaryKey.pfx" />
+    <None Include="cores\$(Platform)\cores\*.lck" />
     <None Include="ANGLE\$(Platform)\*.dll" />
     <None Include="MESA\$(Platform)\*.dll" />
+    <None Include="cores\$(Platform)\*.dll" />
+    <None Include="RetroArch-msvcUWP_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\uwp\uwp_func.h">


### PR DESCRIPTION
## Description
This is a simple edit too the projects vcxproj.filters & vcxproj adding an additional include for *.lck file-type, this allows the project with publishers discretion the added ability for core locks to be included along side the core .dlls 

With this change, you can add the .lck files into cores/$platform/cores and they will pack with the rest of the program.

Example of core lock file.
![image](https://github.com/aerisarn/RetroArch-uwp/assets/22002023/a537db08-f349-4194-bd14-7bf07d431972)

## Related Issues
None

## Related Pull Requests
None

## Reviewers
@aerisarn
